### PR TITLE
Add property support of "rendered" and React classSet.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,14 @@ module.exports = React.createClass({
       r.div({className: 'example'}, [
         r.h1('Hello World!'),
         r.h2('This is React.js markup')
-        r(AnotherComponent, {foo: 'bar'})
+        r(AnotherComponent, {foo: 'bar'}),
+        r.div({
+          className: { // automatically use React classSet
+            foo: this.props.foo,
+            bar: this.props.bar
+          },
+          rendered: this.props.foo // div won't render if rendered === false
+        })
       ])
     );
   }
@@ -40,3 +47,9 @@ Returns a React element
 - **component** `Function` - A React.js Component class created with `React.createClass`
 - **properties** `Object` - An object containing the properties you'd like to set on the element
 - **children** `Array|String` - An array of `r` children or a string. This will create child elements or a text node, respectively.
+
+#### Special Properties
+
+- **rendered** `Boolean` - If strictly to false, React will skip rendering the target component.
+
+- **className** `String|Object` - If the className value is an object, apply React.addons.classSet() automatically.

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-var React = require('react');
+var React = require('react/addons');
 
 module.exports = r;
 
@@ -19,6 +19,13 @@ function r(component, properties, children) {
     properties = {};
   }
 
+  if (properties.rendered === false) {
+    // React skips the component rendering if render() returns null.
+    return null;
+  }
+
+  processClasses(properties);
+
   // Set a default key to prevent React warnings
   if (!properties.key) {
     properties.key = component;
@@ -28,6 +35,15 @@ function r(component, properties, children) {
   }
 
   return React.createElement(component, properties, children);
+}
+
+// Wraps the className property value with React classSet if it's an object.
+function processClasses(properties) {
+  var className = properties.className;
+
+  if (className && typeof className === 'object') {
+    properties.className = React.addons.classSet(className);
+  }
 }
 
 function createTagFn(tag) {

--- a/test/fixtures/render-types.js
+++ b/test/fixtures/render-types.js
@@ -46,5 +46,28 @@ module.exports = {
         r.span('A child')
       ])
     )
+  },
+  componentWithUnrenderedChild: {
+    html: '<div><h1></h1><span></span></div>',
+    dom: (
+      r(Component, [
+        r.span(),
+        r.div({rendered: false})
+      ])
+    )
+  },
+  componentWithDynamicClassNames: {
+    html: '<div><h1></h1><div class="class1 class2"></div></div>',
+    dom: (
+      r(Component, [
+        r.div({
+          className: {
+            class1: true,
+            class2: true,
+            class3: false
+          }
+        })
+      ])
+    )
   }
 };


### PR DESCRIPTION
Add property "rendered". If set to false, React will skip the rendering of the element.
Add support for React classSet. If the className property value is an object, wrap the property value with React.addons.classSet().
