### PR TITLE
Fix the bug that React only renders the first of the child elements of t...

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,15 +26,10 @@ function r(component, properties, children) {
 
   processClasses(properties);
 
-  // Set a default key to prevent React warnings
-  if (!properties.key) {
-    properties.key = component;
-    if (typeof component === 'function') {
-      properties.key = component.displayName || 'customComponent';
-    }
-  }
+  var args = [component, properties];
+  args = args.concat(children);
 
-  return React.createElement(component, properties, children);
+  return React.createElement.apply(React, args);
 }
 
 // Wraps the className property value with React classSet if it's an object.

--- a/test/index.js
+++ b/test/index.js
@@ -21,8 +21,7 @@ test('An html tag', function t(assert) {
 
   var div = r.div();
 
-  assert.equal(div.key, 'div',
-    'sets a default key property');
+  assert.ok(div, 'create an element');
 });
 
 test('An html tag with a key property', function t(assert) {
@@ -39,17 +38,7 @@ test('A component', function t(assert) {
 
   var component = r(createComponent());
 
-  assert.equal(component.key, 'customComponent',
-    'sets a default key property');
-});
-
-test('A component with a displayName', function t(assert) {
-  assert.plan(1);
-
-  var component = r(createComponent({displayName: 'fooBar'}));
-
-  assert.equal(component.key, 'fooBar',
-    'uses the displayName for the key property');
+  assert.ok(component, 'create an element from a component');
 });
 
 test('A component with a key property', function t(assert) {


### PR DESCRIPTION
React uses the key property to identify the elements.
If the elements have the same key value, React will only render the first child element of the same type.

If the children are passed into createElement() as an array, React throws some warnings regarding unassigned keys.
However, if the children are passed as varargs, React permits this and assigns automatic keys.
