### PR TITLE
Improve the performance to create elements.

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,10 +26,15 @@ function r(component, properties, children) {
 
   processClasses(properties);
 
-  var args = [component, properties];
-  args = args.concat(children);
+  if (children) {
+    var args = [component, properties];
+    args = args.concat(children);
 
-  return React.createElement.apply(React, args);
+    return React.createElement.apply(React, args);
+  } else {
+    // Skip the expensive array operations if there are no children.
+    return React.createElement(component, properties);
+  }
 }
 
 // Wraps the className property value with React classSet if it's an object.

--- a/test/index.js
+++ b/test/index.js
@@ -17,20 +17,22 @@ test('Tags and components rendered with different args', function t(assert) {
 });
 
 test('An html tag', function t(assert) {
-  assert.plan(1);
+  assert.plan(2);
 
   var div = r.div();
 
   assert.ok(div, 'create an element');
+  assert.equal(React.Children.count(div.props.children), 0, 'has no children');
 });
 
-test('An html tag with a key property', function t(assert) {
-  assert.plan(1);
+test('An html tag with a key property and a child', function t(assert) {
+  assert.plan(2);
 
-  var div = r.div({key: 'someKey'});
+  var div = r.div({key: 'someKey'}, [r.span('span')]);
 
   assert.equal(div.key, 'someKey',
     'uses the passed key property');
+  assert.equal(React.Children.count(div.props.children), 1, 'has one child');
 });
 
 test('A component', function t(assert) {
@@ -41,7 +43,7 @@ test('A component', function t(assert) {
   assert.ok(component, 'create an element from a component');
 });
 
-test('A component with a key property', function t(assert) {
+test('A component with a key property and a child', function t(assert) {
   assert.plan(1);
 
   var component = r(createComponent(), {key: 'someKey'});


### PR DESCRIPTION
Skip the argument array operations if there are no children.
Also fix the bug that if the element has no children, an undefined is passed into its child list.
