### PR TITLE
Move React into peerDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     }
   ],
   "main": "index.js",
-  "dependencies": {
-    "react": "^0.12.2"
+  "peerDependencies": {
+    "react": "0.12.x"
   },
   "devDependencies": {
     "lint-trap": "^0.4.9",


### PR DESCRIPTION
Move React module from dependencies to peerDependencies.

This is going to reduce size by loading React multiple times.
In addition, this causes a bug due to loading several different versions of React.
