### PR TITLE
Pass children as arguments

### DIFF
--- a/test/fixtures/create-component.js
+++ b/test/fixtures/create-component.js
@@ -12,7 +12,9 @@ function createComponent(properties) {
       return (
         r.div([
           r.h1(this.props.title),
-          this.props.children
+          // This tests that children are passed down correctly to
+          // components that use React.DOM directly (and don't warn)
+          React.DOM.div(null, this.props.children)
         ])
       );
     }

--- a/test/fixtures/render-types.js
+++ b/test/fixtures/render-types.js
@@ -26,13 +26,13 @@ module.exports = {
     )
   },
   component: {
-    html: '<div><h1></h1></div>',
+    html: '<div><h1></h1><div></div></div>',
     dom: (
       r(Component)
     )
   },
   componentWithChildren: {
-    html: '<div><h1></h1><span>A child</span></div>',
+    html: '<div><h1></h1><div><span>A child</span></div></div>',
     dom: (
       r(Component, [
         r.span('A child')
@@ -40,7 +40,7 @@ module.exports = {
     )
   },
   componentWithPropsAndChildren: {
-    html: '<div><h1>Hello World</h1><span>A child</span></div>',
+    html: '<div><h1>Hello World</h1><div><span>A child</span></div></div>',
     dom: (
       r(Component, {title: 'Hello World'}, [
         r.span('A child')
@@ -48,7 +48,7 @@ module.exports = {
     )
   },
   componentWithUnrenderedChild: {
-    html: '<div><h1></h1><span></span></div>',
+    html: '<div><h1></h1><div><span></span></div></div>',
     dom: (
       r(Component, [
         r.span(),
@@ -57,7 +57,8 @@ module.exports = {
     )
   },
   componentWithDynamicClassNames: {
-    html: '<div><h1></h1><div class="class1 class3 class4"></div></div>',
+    html: '<div><h1></h1><div><div class="class1 class3 class4"></div></div>' +
+      '</div>',
     dom: (
       r(Component, [
         r.div({

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,5 @@
 'use strict';
+var console = require('console');
 var forEach = require('for-each');
 var React = require('react');
 var test = require('tape');
@@ -8,48 +9,66 @@ var r = require('../');
 var renderTypes = require('./fixtures/render-types');
 
 test('Tags and components rendered with different args', function t(assert) {
-  assert.plan(Object.keys(renderTypes).length);
-
   forEach(renderTypes, function renderCorrectly(data, name) {
-    assert.equal(getDOMString(data.dom), data.html,
+    var dom;
+    var messages = catchWarns(function makeDomString() {
+      dom = getDOMString(data.dom);
+    });
+
+    assert.equal(messages.length, 0,
+      '`' + name + '` does not log warnings');
+
+    assert.equal(dom, data.html,
       '`' + name + '` renders correctly');
   });
+  assert.end();
 });
 
 test('An html tag', function t(assert) {
-  assert.plan(1);
-
   var div = r.div();
-
-  assert.ok(div, 'create an element');
+  assert.ok(div,
+    'creates an element');
+  assert.end();
 });
 
 test('An html tag with a key property', function t(assert) {
-  assert.plan(1);
-
   var div = r.div({key: 'someKey'});
-
   assert.equal(div.key, 'someKey',
     'uses the passed key property');
+  assert.end();
 });
 
 test('A component', function t(assert) {
-  assert.plan(1);
-
   var component = r(createComponent());
-
-  assert.ok(component, 'create an element from a component');
+  assert.ok(component,
+    'creates an element');
+  assert.end();
 });
 
 test('A component with a key property', function t(assert) {
-  assert.plan(1);
-
   var component = r(createComponent(), {key: 'someKey'});
-
   assert.equal(component.key, 'someKey',
     'uses the passed key property');
+  assert.end();
 });
 
 function getDOMString(reactElement) {
   return React.renderToStaticMarkup(reactElement);
+}
+
+function catchWarns(fn) {
+  var messages = [];
+
+  /* eslint-disable no-console */
+  var originalWarn = console.warn;
+  console.warn = warn;
+  fn();
+  console.warn = originalWarn;
+  /* esline-enable no-console */
+
+  return messages;
+
+  function warn(message) {
+    messages.push(message);
+  }
 }


### PR DESCRIPTION
Sometimes components (like react-router) will call `React.DOM` directly with the children props passed down from its parent. Unfortunately, if this is an array (as it is with r-dom), React will log key warnings. This fixes that issue by always passing children in to `React.createElement` as arguments.

cc @cain-uber @rhobot 