### PR TITLE
Fix the bug that classSet won't apply if className is empty.

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,17 +52,15 @@ function processClasses(properties) {
   }
 
   var className = properties.className;
-  if (!className || typeof className !== 'string') {
-    return;
-  }
+  if (className && typeof className === 'string') {
+    var names = className.match(/\S+/g);
+    if (!names) {
+      return;
+    }
 
-  var names = className.match(/\S+/g);
-  if (!names) {
-    return;
-  }
-
-  for (var i = 0; i < names.length; i++) {
-    classSetConfig[names[i]] = true;
+    for (var i = 0; i < names.length; i++) {
+      classSetConfig[names[i]] = true;
+    }
   }
 
   properties.className = classSet(classSetConfig);

--- a/test/fixtures/render-types.js
+++ b/test/fixtures/render-types.js
@@ -56,6 +56,20 @@ module.exports = {
       ])
     )
   },
+  componentWithClassset: {
+    html: '<div><h1></h1><div><div class="class1 class2"></div></div></div>',
+    dom: (
+      r(Component, [
+        r.div({
+          classSet: {
+            class1: true,
+            class2: true,
+            class3: false
+          }
+        })
+      ])
+    )
+  },
   componentWithDynamicClassNames: {
     html: '<div><h1></h1><div><div class="class1 class3 class4"></div></div>' +
       '</div>',


### PR DESCRIPTION
When we process classSet, we return a bit too soon if the className property doesn't exist.
Only if both classSet and className present, we copy className fields onto classSet.

If className is empty, just do regular react classSet.

Also updated the test to reflect this change.