### PR TITLE
Add property inheritance to conveniently pass parent properties down to child components.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,37 @@ Returns a React element
 - **isRendered** `Boolean` - If strictly to false, React will skip rendering the target component.
 
 - **classSet** `Object` - Apply React.addons.classSet() automatically and assign to className.
+
+- **inheritProps** `Object` - Properties inherited from the parent component.
+
+```js
+var Parent = React.createClass({
+  render: function render() {
+    r(Child, {
+      inheritProps: this.props // Inherits all properties from parent.
+    });
+  }
+});
+
+var Parent = React.createClass({
+  render: function render() {
+    r(Child, {
+      inheritProps: {
+        props: this.props,
+        includes: ['id', 'name'] // Inherits properties named ['id', 'name'].
+      }
+    });
+  }
+});
+
+var Parent = React.createClass({
+  render: function render() {
+    r(Child, {
+      inheritProps: {
+        props: this.props,
+        excludes: ['id', 'name'] // Inherits all properties from parent except ['id', 'name'].
+      }
+    });
+  }
+});
+```

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 var React = require('react');
 var classSet = require('react/lib/cx');
-var assign = require('react/lib/Object.assign');
+var window = require('global/window');
 
 module.exports = r;
 
@@ -77,22 +77,39 @@ function processPropertyInheritance(properties) {
     return;
   }
 
+  var sourceProps;
+
   if (inheritProps.props) {
-    var sourceProps = inheritProps.props;
+    sourceProps = inheritProps.props;
 
     if (Array.isArray(inheritProps.includes)) {
       inheritProps.includes.forEach(function forEach(propName) {
-        properties[propName] = sourceProps[propName];
+        assignProperty(sourceProps, properties, propName);
       });
     } else if (Array.isArray(inheritProps.excludes)) {
       Object.keys(sourceProps).forEach(function forEach(propName) {
         if (inheritProps.excludes.indexOf(propName) === -1) {
-          properties[propName] = sourceProps[propName];
+          assignProperty(sourceProps, properties, propName);
         }
       });
     }
   } else {
-    assign(properties, inheritProps);
+    sourceProps = inheritProps;
+    Object.keys(sourceProps).forEach(function forEach(propName) {
+      assignProperty(sourceProps, properties, propName);
+    });
+  }
+}
+
+// Assigns the property specified by name from the source to the target.
+// A warning is thrown if the property with the same name already exists.
+function assignProperty(sourceProps, targetProps, propName) {
+  if (propName in targetProps) {
+    var warning = ['Property', propName,
+      'already exits in the target properties.'].join(' ');
+    window.console.warn(warning);
+  } else {
+    targetProps[propName] = sourceProps[propName];
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 var React = require('react');
 var classSet = require('react/lib/cx');
+var assign = require('react/lib/Object.assign');
 
 module.exports = r;
 
@@ -26,6 +27,7 @@ function r(component, properties, children) {
   }
 
   processClasses(properties);
+  processPropertyInheritance(properties);
 
   // Don't use an array if there's only one child
   if (Array.isArray(children) && children.length === 1) {
@@ -64,6 +66,34 @@ function processClasses(properties) {
   }
 
   properties.className = classSet(classSetConfig);
+}
+
+// Processes the property inheritance.
+// The inheritProps property could take this.props from the parent component,
+// or a config object that specifies properties to include / exludes.
+function processPropertyInheritance(properties) {
+  var inheritProps = properties.inheritProps;
+  if (!inheritProps) {
+    return;
+  }
+
+  if (inheritProps.props) {
+    var sourceProps = inheritProps.props;
+
+    if (Array.isArray(inheritProps.includes)) {
+      inheritProps.includes.forEach(function forEach(propName) {
+        properties[propName] = sourceProps[propName];
+      });
+    } else if (Array.isArray(inheritProps.excludes)) {
+      Object.keys(sourceProps).forEach(function forEach(propName) {
+        if (inheritProps.excludes.indexOf(propName) === -1) {
+          properties[propName] = sourceProps[propName];
+        }
+      });
+    }
+  } else {
+    assign(properties, inheritProps);
+  }
 }
 
 // Creates an array of React.createElement arguments in a performant way

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   ],
   "main": "index.js",
   "dependencies": {
+    "global": "^4.3.0",
     "react": "^0.12.2"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,8 @@ var createComponent = require('./fixtures/create-component');
 var r = require('../');
 var renderTypes = require('./fixtures/render-types');
 
+require('./test-inheritance');
+
 test('Tags and components rendered with different args', function t(assert) {
   forEach(renderTypes, function renderCorrectly(data, name) {
     var dom;

--- a/test/test-inheritance.js
+++ b/test/test-inheritance.js
@@ -1,0 +1,110 @@
+'use strict';
+
+var test = require('tape');
+var React = require('react');
+var r = require('../');
+
+var name = 'name';
+var id = 33;
+var valid = true;
+
+function text(value) {
+  return value ? String(value) : '';
+}
+
+function createChildComponent() {
+  return React.createClass({
+    propTypes: {
+      id: React.PropTypes.number,
+      name: React.PropTypes.string,
+      valid: React.PropTypes.bool
+    },
+
+    render: function render() {
+      return r.div([
+        text(this.props.id),
+        text(this.props.name),
+        text(this.props.valid)
+      ]);
+    }
+  });
+}
+
+function checkParentRendering(assert, ParentComponent, values, message) {
+  var renderedHtml = React.renderToStaticMarkup(r(ParentComponent, {
+    id: id,
+    name: name,
+    valid: valid
+  }));
+
+  var expected = '<div>' + values.join('') + '</div>';
+  assert.equal(renderedHtml, expected, message);
+}
+
+test('Test property inheritance with empty properties.', function t(assert) {
+  assert.plan(1);
+
+  var Parent = React.createClass({
+    render: function render() {
+      return r(createChildComponent(), {
+        inheritProps: this.props
+      });
+    }
+  });
+
+  var renderedHtml = React.renderToStaticMarkup(r(Parent));
+  var expected = '<div></div>';
+  assert.equal(expected, renderedHtml,
+    'Empty properties should not break property inheritance.');
+});
+
+test('Test basic property inheritance.', function t(assert) {
+  assert.plan(1);
+
+  var Parent = React.createClass({
+    render: function render() {
+      return r(createChildComponent(), {
+        inheritProps: this.props
+      });
+    }
+  });
+
+  checkParentRendering(assert, Parent, [id, name, valid],
+    'Component rendered properly with basic property inheritance.');
+});
+
+test('Test property inheritance with includes.', function t(assert) {
+  assert.plan(1);
+
+  var Parent = React.createClass({
+    render: function render() {
+      return r(createChildComponent(), {
+        inheritProps: {
+          props: this.props,
+          includes: ['id', 'name']
+        }
+      });
+    }
+  });
+
+  checkParentRendering(assert, Parent, [id, name],
+    'Component rendered properly with property inheritance includes.');
+});
+
+test('Test property inheritance with excludes.', function t(assert) {
+  assert.plan(1);
+
+  var Parent = React.createClass({
+    render: function render() {
+      return r(createChildComponent(), {
+        inheritProps: {
+          props: this.props,
+          excludes: ['id']
+        }
+      });
+    }
+  });
+
+  checkParentRendering(assert, Parent, [name, valid],
+    'Component rendered properly with property inheritance excludes.');
+});

--- a/test/test-inheritance.js
+++ b/test/test-inheritance.js
@@ -5,7 +5,7 @@ var React = require('react');
 var r = require('../');
 
 var name = 'name';
-var id = 33;
+var id = 1455;
 var valid = true;
 
 function text(value) {
@@ -107,4 +107,24 @@ test('Test property inheritance with excludes.', function t(assert) {
 
   checkParentRendering(assert, Parent, [name, valid],
     'Component rendered properly with property inheritance excludes.');
+});
+
+test('Test conflicting property names.', function t(assert) {
+  assert.plan(1);
+
+  var childId = 685;
+  var childName = 'child';
+
+  var Parent = React.createClass({
+    render: function render() {
+      return r(createChildComponent(), {
+        inheritProps: this.props,
+        id: childId,
+        name: childName
+      });
+    }
+  });
+
+  checkParentRendering(assert, Parent, [childId, childName, valid],
+    'Component rendered properly without explicit properties overriden.');
 });


### PR DESCRIPTION
Conveniently pass down parent properties to child components. This small feature saves many boilerplate code where we'd need to manually map the parent properties to child properties or assign blocks that copy over the parent properties.

Previously, people have to do:

<pre>
var Parent = React.createClass({
  render: function render() {
    r(Child, {
      id: this.props.id,
      name: this.props.name,
      valid: this.props.valid
      // the list could be long for complicated components and tedious for wrapper components!
    });
  }
});
</pre>

<pre>
var Parent = React.createClass({
  render: function render() {
    r(Child, {
      inheritProps: this.props // Inherits all properties from parent.
    });
  }
});

var Parent = React.createClass({
  render: function render() {
    r(Child, {
      inheritProps: {
        props: this.props,
        includes: ['id', 'name'] // Inherits properties named ['id', 'name'].
      }
    });
  }
});

var Parent = React.createClass({
  render: function render() {
    r(Child, {
      inheritProps: {
        props: this.props,
        excludes: ['id', 'name'] // Inherits all properties from parent except ['id', 'name'].
      }
    });
  }
});
</pre>