### PR TITLE
isRendered: false -> falsy like JSX rendering behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ coverage/
 .editorconfig
 .jscsrc
 .jshintrc
+
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ module.exports = React.createClass({
             foo: this.props.foo,
             bar: this.props.bar
           },
-          isRendered: this.props.foo // div won't render if isRendered === false
+          isRendered: this.props.foo // div won't render if isRendered is falsy
         })
       ])
     );
@@ -50,6 +50,6 @@ Returns a React element
 
 #### Special Properties
 
-- **isRendered** `Boolean` - If strictly to false, React will skip rendering the target component.
+- **isRendered** `"Boolean"` - If falsy, React will skip rendering the target component.
 
 - **classSet** `Object` - Apply React.addons.classSet() automatically and assign to className.

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function r(component, properties, children) {
     properties = {};
   }
 
-  if (properties.isRendered === false) {
+  if (properties.isRendered !== undefined && !properties.isRendered) {
     // React skips the component rendering if render() returns null.
     return null;
   }

--- a/test/fixtures/render-types.js
+++ b/test/fixtures/render-types.js
@@ -63,12 +63,39 @@ module.exports = {
       ])
     )
   },
-  componentWithUnrenderedChild: {
+  componentWithUnrenderedChildWithFalse: {
     html: '<div><h1></h1><div><span></span></div></div>',
     dom: (
       r(Component, [
         r.span(),
         r.div({isRendered: false}, 'Should not show up')
+      ])
+    )
+  },
+  componentWithUnrenderedChildWithFalsy: {
+    html: '<div><h1></h1><div><span></span></div></div>',
+    dom: (
+      r(Component, [
+        r.span(),
+        r.div({isRendered: 0}, 'Should not show up')
+      ])
+    )
+  },
+  componentWithRenderedChildWithTruth: {
+    html: '<div><h1></h1><div><span></span><div>show up</div></div></div>',
+    dom: (
+      r(Component, [
+        r.span(),
+        r.div({isRendered: true}, 'show up')
+      ])
+    )
+  },
+  componentWithRenderedChildWithTruthy: {
+    html: '<div><h1></h1><div><span></span><div>show up</div></div></div>',
+    dom: (
+      r(Component, [
+        r.span(),
+        r.div({isRendered: 1}, 'show up')
       ])
     )
   },


### PR DESCRIPTION
In JSX, the way rendering of a component is controlled depends on truthy/falsy value like this

```jsx
// If isRendered is falsy, Component is not rendered.
return isRendered && <Component />;
```

`isRendered` in r-dom must be strictly false not to render the component, which confuses some consumers.