### PR TITLE
Add support for React 0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ module.exports = React.createClass({
         r.h2('This is React.js markup'),
         r(AnotherComponent, {foo: 'bar'}),
         r.div({
-          classSet: { // automatically use React classSet
+          classSet: { // Automatically use `classnames` module for classSet
             foo: this.props.foo,
             bar: this.props.bar
           },

--- a/package.json
+++ b/package.json
@@ -34,10 +34,13 @@
   ],
   "main": "index.js",
   "dependencies": {
-    "react": ">=0.12.0 <0.14.0",
     "classnames": "^1.1.4"
   },
+  "peerDependencies": {
+    "react": "0.12.x - 0.14.x"
+  },
   "devDependencies": {
+    "react": "0.12.x - 0.14.x",
     "lint-trap": "^0.4.9",
     "tape": "^3.0.0",
     "tap-spec": "^1.0.0",


### PR DESCRIPTION
- Moved React to peerDependencies
- Modified semver range to include React 0.14
- Updated to README to reflect usage of `classnames` module