### PR TITLE
Update classnames dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "main": "index.js",
   "dependencies": {
-    "classnames": "^1.1.4",
+    "classnames": "^2.2.5",
     "object.omit": "^2.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
The only breaking change in classnames 2.x is the use of Array.isArray
which means that a polyfill is needed for IE 8 support.

It shouldn't be a problem though because Array.isArray is used in r-dom
itself.