### PR TITLE
handle undefined value passed to isRendered

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function r(component, properties, children) {
 
   properties = properties || {};
 
-  if (properties.isRendered !== undefined && !properties.isRendered) {
+  if (properties.hasOwnProperty('isRendered') && !properties.isRendered) {
     // React skips the component rendering if render() returns null.
     return null;
   }

--- a/test/fixtures/render-types.js
+++ b/test/fixtures/render-types.js
@@ -97,6 +97,15 @@ module.exports = {
       ])
     )
   },
+  componentWithUnrenderedChildWithUndefined: {
+  html: '<div><h1></h1><div><span></span></div></div>',
+  dom: (
+    r(Component, [
+      r.span(),
+      r.div({isRendered: undefined && true}, 'Should not show up')
+    ])
+  )
+},
   componentWithRenderedChildWithTruth: {
     html: '<div><h1></h1><div><span></span><div>show up</div></div></div>',
     dom: (

--- a/test/fixtures/render-types.js
+++ b/test/fixtures/render-types.js
@@ -102,7 +102,7 @@ module.exports = {
   dom: (
     r(Component, [
       r.span(),
-      r.div({isRendered: undefined && true}, 'Should not show up')
+      r.div({isRendered: void 0}, 'Should not show up')
     ])
   )
 },


### PR DESCRIPTION
Currently isRendered incorrectly handles undefined values explicitly passed to it. isRendered should evaluate to falsey for the following use case:
`
var item;
r(ItemComponent, {isRendered: item, item});
`